### PR TITLE
make sure this addon is run before `ember-cli-htmlbars`

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,10 @@
     "edition": "octane"
   },
   "ember-addon": {
-    "configPath": "tests/dummy/config"
+    "configPath": "tests/dummy/config",
+    "before": [
+      "ember-cli-htmlbars",
+      "ember-cli-htmlbars-inline-precompile"
+    ]
   }
 }


### PR DESCRIPTION
This was causing an issue where the ast-transform wasn't being run for co-located components in the consuming app. Making sure it's run before `ember-cli-htmlbars` and `ember-cli-htmlbars-inline-precompile` fixes this issue (for some reason)

Note: even if you tried to recreate this issue in the dummy app of this addon, the addon order is different than it would be in a **real** app so it was impossible to recreate this issue in tests 😫 