### PR TITLE
[SOX-15214] Fix TemplateLiteral value

### DIFF
--- a/lib/format-message-replace.js
+++ b/lib/format-message-replace.js
@@ -50,6 +50,19 @@ module.exports = declare((api) => {
 });
 
 const getVariableValue = (args, variable) => {
-  return args?.properties?.find?.((p) => p.key?.name === variable)?.value
-    ?.value;
+  const property = args?.properties?.find?.((p) => p.key?.name === variable);
+  const propertyValue = property?.value;
+
+  let value = propertyValue?.value;
+  if (propertyValue?.type === 'TemplateLiteral') {
+    // For a string type TemplateLiteral we only take first quasi
+    // because dynamic expressions / concatenation inside a message are not allowed anyways.
+    value = propertyValue.quasis[0].value.cooked;
+  }
+
+  // Replicates what formatjs does by default
+  // Formatjs has an option 'preserveWhitespace' which is `false` by default
+  // We need to replicate this to also make certain strings equal regardless of their format.
+  // See `messageWithBackticks` and `messageWithMultilineBackticks` inside ../node-tests/fixtures/format-message-replace/output
+  return value?.trim().replace(/\s+/gm, ' ');
 };

--- a/lib/format-message-replace.js
+++ b/lib/format-message-replace.js
@@ -1,55 +1,66 @@
 const { declare } = require('@babel/helper-plugin-utils');
 const { interpolateName } = require('@formatjs/ts-transformer');
 
-module.exports = declare((api) => {
-  api.assertVersion(7);
+module.exports = function (pluginOptions) {
+  return declare((api) => {
+    api.assertVersion(7);
 
-  return {
-    name: 'format-message-replace',
+    const preserveWhitespace = pluginOptions.preserveWhitespace;
+    const idInterpolationPattern = pluginOptions.idInterpolationPattern;
 
-    visitor: {
-      CallExpression(path) {
-        if (
-          path.node?.callee?.object?.property?.name === 'intl' &&
-          path.node?.callee?.property?.name === 'formatMessage'
-        ) {
-          path.node.callee.property.name = 't';
+    return {
+      name: 'format-message-replace',
 
-          const args = path.node?.arguments;
-          const firstHash = args?.[0];
-          const valuesHash = args?.[1];
-          const defaultMessage = getVariableValue(firstHash, 'defaultMessage');
-          const description = getVariableValue(firstHash, 'description');
-          const translationId = getVariableValue(firstHash, 'id');
+      visitor: {
+        CallExpression(path) {
+          if (
+            path.node?.callee?.object?.property?.name === 'intl' &&
+            path.node?.callee?.property?.name === 'formatMessage'
+          ) {
+            path.node.callee.property.name = 't';
 
-          const idInterpolationPattern = '[sha512:contenthash:base64:6]';
+            const args = path.node?.arguments;
+            const firstHash = args?.[0];
+            const valuesHash = args?.[1];
+            const defaultMessage = getVariableValue(
+              firstHash,
+              'defaultMessage',
+              preserveWhitespace
+            );
+            const description = getVariableValue(
+              firstHash,
+              'description',
+              true
+            );
+            const translationId = getVariableValue(firstHash, 'id', false);
 
-          const id = interpolateName(
-            {
-              resourcePath: api.File.path,
-            },
-            idInterpolationPattern,
-            {
-              content: description
-                ? `${defaultMessage}#${description}`
-                : defaultMessage,
-            }
-          );
+            const id = interpolateName(
+              {
+                resourcePath: api.File.path,
+              },
+              idInterpolationPattern,
+              {
+                content: description
+                  ? `${defaultMessage}#${description}`
+                  : defaultMessage,
+              }
+            );
 
-          path.node.arguments[0] = {
-            type: 'StringLiteral',
-            value: translationId || id,
-          };
+            path.node.arguments[0] = {
+              type: 'StringLiteral',
+              value: translationId || id,
+            };
 
-          path.node.arguments[1] = valuesHash;
-          path.node.arguments[2] = null;
-        }
+            path.node.arguments[1] = valuesHash;
+            path.node.arguments[2] = null;
+          }
+        },
       },
-    },
-  };
-});
+    };
+  });
+};
 
-const getVariableValue = (args, variable) => {
+const getVariableValue = (args, variable, preserveWhitespace) => {
   const property = args?.properties?.find?.((p) => p.key?.name === variable);
   const propertyValue = property?.value;
 
@@ -64,5 +75,9 @@ const getVariableValue = (args, variable) => {
   // Formatjs has an option 'preserveWhitespace' which is `false` by default
   // We need to replicate this to also make certain strings equal regardless of their format.
   // See `messageWithBackticks` and `messageWithMultilineBackticks` inside ../node-tests/fixtures/format-message-replace/output
-  return value?.trim().replace(/\s+/gm, ' ');
+  if (!preserveWhitespace) {
+    return value?.trim().replace(/\s+/gm, ' ');
+  }
+
+  return value;
 };

--- a/node-tests/fixtures/format-message-replace/code.js
+++ b/node-tests/fixtures/format-message-replace/code.js
@@ -66,4 +66,58 @@ export default class AController extends Controller {
 			description: 'description for the message',
 		});
 	}
+
+	get messageWithBackticks() {
+		return this.intl.formatMessage({
+			defaultMessage: `The user is: {name}, {description} messageWithBackticks`,
+			description: 'this is a description',
+		}, {
+			name: this.args.user.name,
+			description: 'description for the message',
+		});
+	}
+
+  get messageWithMultilineBackticks() {
+		return this.intl.formatMessage({
+			defaultMessage: `
+        The user is: {name}, {description}
+        messageWithBackticks
+      `,
+			description: 'this is a description',
+		}, {
+			name: this.args.user.name,
+			description: 'description for the message',
+		});
+	}
+
+  get messageWithMultilineBackticksAndSelect() {
+    	return this.intl.formatMessage({
+				defaultMessage: `
+            {hasHours, select, true {{hours}h} other {}}
+            {hasMinutes, select, true {{minutes}m} other {}}
+            {hasSeconds, select, true {{seconds}s} other {}}
+        `,
+			},
+			{
+				hasHours: false,
+				hasMinutes: false,
+				hasSeconds: false,
+				hours: 0,
+				minutes: 0,
+				seconds: 0,
+			},
+		);
+	}
+
+  get messageWithMultilineBackticksWithoutDescription() {
+		return this.intl.formatMessage({
+			defaultMessage: `
+        The user is: {name}, {description}
+        messageWithBackticks
+      `,
+		}, {
+			name: this.args.user.name,
+			description: 'description for the message',
+		});
+	}
 }

--- a/node-tests/fixtures/format-message-replace/output.js
+++ b/node-tests/fixtures/format-message-replace/output.js
@@ -44,4 +44,36 @@ export default class AController extends Controller {
       description: 'description for the message',
     });
   }
+
+  get messageWithBackticks() {
+    return this.intl.t('rV3UdV', {
+      name: this.args.user.name,
+      description: 'description for the message',
+    });
+  }
+
+  get messageWithMultilineBackticks() {
+    return this.intl.t('rV3UdV', {
+      name: this.args.user.name,
+      description: 'description for the message',
+    });
+  }
+
+  get messageWithMultilineBackticksAndSelect() {
+    return this.intl.t('8BgCEw', {
+      hasHours: false,
+      hasMinutes: false,
+      hasSeconds: false,
+      hours: 0,
+      minutes: 0,
+      seconds: 0,
+    });
+  }
+
+  get messageWithMultilineBackticksWithoutDescription() {
+    return this.intl.t('bHc0dX', {
+      name: this.args.user.name,
+      description: 'description for the message',
+    });
+  }
 }

--- a/node-tests/format-message-replace-test.js
+++ b/node-tests/format-message-replace-test.js
@@ -1,9 +1,12 @@
 const { join } = require('path');
 const pluginTester = require('babel-plugin-tester').default;
-const formatMessageReplace = require('../lib/format-message-replace');
+const FormatMessageReplace = require('../lib/format-message-replace');
 
 pluginTester({
-  plugin: formatMessageReplace,
+  plugin: FormatMessageReplace({
+    idInterpolationPattern: '[sha512:contenthash:base64:6]',
+    preserveWhitespace: false,
+  }),
   pluginName: 'format message replace',
   fixtures: join(__dirname, 'fixtures'),
 });


### PR DESCRIPTION
- Fixed message hash for TemplateLiteral type
- Changed plugin into a factory so it can accept arguments. 
- Added `preserveWhitespace` option in order to inline with formatjs, defaults to `false`
- Added a util method for getting addon options.