### PR TITLE
Updated to use lokalise translation key for a translations object

### DIFF
--- a/lib/lang-convert.js
+++ b/lib/lang-convert.js
@@ -15,7 +15,7 @@ class LangConvert extends Filter {
     let result = {};
 
     for (let key in parsed) {
-      result[key] = parsed[key].defaultMessage;
+      result[key] = parsed[key].translation;
     }
 
     return JSON.stringify(result, null, 2);

--- a/node-tests/lang-convert.js
+++ b/node-tests/lang-convert.js
@@ -39,10 +39,10 @@ describe('Tag Generator', function () {
     const files = await buildFiles({
       'en-us.json': `{
   "+/sgnu": {
-    "defaultMessage": "Assessment Templates"
+    "translation": "Assessment Templates"
   },
   "+5S38p": {
-    "defaultMessage": "Tasks are not in the same status. No bulk workflow actions can be performed."
+    "translation": "Tasks are not in the same status. No bulk workflow actions can be performed."
   }
 }`,
     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soxhub/ember-formatjs",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "The default blueprint for ember-cli addons.",
   "keywords": [
     "ember-addon"


### PR DESCRIPTION
Lokalise uses `translation` as the key for a translation object

ie: 
``` json
"xxwsPm": {
    "translation": "Accept & Close"
  },
```