### PR TITLE
fix: id has to be generaged based on trimmed message and description

### DIFF
--- a/lib/replace-key-transform.js
+++ b/lib/replace-key-transform.js
@@ -9,8 +9,15 @@ module.exports = function (idInterpolationPattern) {
 
     function transformHelper(node) {
       if (node.path.original === 'format-message') {
-        const defaultMessage = node.params[0]?.original;
-        const description = node.params[1]?.original;
+        // defaultMessage and description were trimmed and multiple white spaces were replaced with a single space,
+        // because generated id has to be the same no matter what is the indentation and new lines.
+        // id has to be generated the same way in soxhub/formatjs/hbs_extractor!!!!!!!!!!!!!!
+        const defaultMessage = node.params[0]?.original
+          ?.trim()
+          .replace(/\s+/gm, ' ');
+        const description = node.params[1]?.original
+          ?.trim()
+          .replace(/\s+/gm, ' ');
         const id = interpolateName(
           {
             resourcePath: fileName,


### PR DESCRIPTION
The different indentations and new lines in the message and description should produce the same id.
**Id is generated based on trimmed message and description and the same logic should be implemented also in soxhub/formatjs/hbs_extractor!!!!!!!!!!!**

```hbs
{{format-message "Default message" "Nice description"}}
```

should extract the same id as the following:

```hbs
{{format-message 
    "Default 
    message" 
    "Nice 
    description"}}
```