### PR TITLE
ci: bump checkout and setup-node to v4 (unbreak the runner)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: 14.x
           cache: yarn
@@ -30,8 +30,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 14.x
           cache: yarn
@@ -60,9 +60,9 @@ jobs:
           - embroider-optimized
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: 14.x
           cache: yarn


### PR DESCRIPTION
CI on this repo cannot run. Both jobs die at step 3, before any project code is touched:

```
[command]/usr/local/bin/yarn cache dir
/home/runner/.cache/yarn/v6
##[error]Cache service responded with 400
```

`actions/setup-node@v2` bundles a cache client that talks to the **retired** GitHub Actions Cache v1 API, so `cache: yarn` fails on every run regardless of what is in the PR. Step outcomes on a recent run:

| Step | Result |
|---|---|
| `actions/checkout@v2` | success |
| Install Node | **failure** |
| Install Dependencies | skipped |
| Lint | skipped |
| Run Tests | skipped |

`yarn install --frozen-lockfile` never executes, so CI is currently validating nothing.

## Change

Bumps `actions/checkout` v2 -> v4 and `actions/setup-node` v2 -> v4 across all three jobs. That moves the cache onto the current service and off the deprecated Node 12/16 action runtimes.

`node-version` is deliberately left at `14.x` to keep this change scoped to unbreaking the runner. Node 14 is long EOL and the `try-scenarios` matrix targets ember 3.20 through canary, so **this may well surface real failures underneath** — that is the point. Right now those failures are invisible.

Opened alongside a dependency-security PR against the same repo that CI could not validate.